### PR TITLE
Add files via upload

### DIFF
--- a/kernel/src/main/java/cn/crowdos/kernel/constraint/PrivacyConstraint/JPaillier.java
+++ b/kernel/src/main/java/cn/crowdos/kernel/constraint/PrivacyConstraint/JPaillier.java
@@ -1,0 +1,15 @@
+package cn.crowdos.kernel.constraint.PrivacyConstraint;
+
+import java.math.BigDecimal;
+
+public class JPaillier {
+    public static BigDecimal[] encryptLocation(BigDecimal latitude, BigDecimal longitude) {
+        // 保留两位小数并减去0.01
+        BigDecimal fuzziness = new BigDecimal("0.01");
+        BigDecimal encryptedLatitude = latitude.setScale(2, BigDecimal.ROUND_DOWN).subtract(fuzziness);
+        BigDecimal encryptedLongitude = longitude.setScale(2, BigDecimal.ROUND_DOWN).subtract(fuzziness);
+
+        // 返回加密后的经度和纬度
+        return new BigDecimal[]{encryptedLatitude, encryptedLongitude};
+    }
+}


### PR DESCRIPTION
使用地理位置模糊进行参与者位置加密
即，在得到准确经纬度后，对数值进行截取，并计算得到边界
使得到的用户位置信息变成一个区域，而不是一个精确的点，
既可以满足任务约束判断的需求，又实现了用户隐私保护的需要